### PR TITLE
Switch to using images.hive.blog for v4vapp avatar

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -254,7 +254,7 @@ export const BrowserConfig = {
         name: 'V4V.app',
         description: 'Hive to Bitcoin Lightning Gateway.',
         icon:
-          'https://v4v.app/site-logo/v4vapp-logo-shadows.svg',
+          'https://images.hive.blog/u/v4vapp/avatar',
         url: 'https://v4v.app/',
         categories: ['finance'],
       },


### PR DESCRIPTION
I noticed the image for my app isn't loading. I was trying to pull an SVG from my server, wrong thing to do.

I've switched it to pull from images.hive.blog like the others.